### PR TITLE
Fix reportlab compilation on Render using Docker

### DIFF
--- a/.render.yaml
+++ b/.render.yaml
@@ -1,9 +1,8 @@
 services:
   - type: web
     name: scrum-api
-    env: python
-    buildCommand: pip install -r requirements.txt
-    startCommand: gunicorn -c gunicorn.conf.py app:app
+    env: docker
+    dockerfilePath: ./Dockerfile
     envVars:
       - key: DATABASE_URL
         fromDatabase:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.11-slim
+
+# Install system dependencies required for reportlab and other packages
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    libfreetype6-dev \
+    libjpeg-dev \
+    libpng-dev \
+    zlib1g-dev \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 10000
+
+# Start command
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app:app"]


### PR DESCRIPTION
# Fix reportlab compilation on Render using Docker

## Summary

This PR resolves the critical deployment failure on Render where the `reportlab` library fails to compile with GCC errors (`error: command '/usr/bin/gcc' failed with exit code 1`). The root cause is that reportlab requires system dependencies (gcc, freetype-dev, libjpeg-dev, etc.) that are not available in Render's native Python runtime.

**Solution**: Migrate from native Python runtime to Docker-based deployment, which gives us full control over the operating system and allows installation of required system dependencies.

**Changes**:
- Added `Dockerfile` with system dependencies required for reportlab compilation
- Updated `.render.yaml` to use Docker runtime instead of native Python runtime
- Maintains existing gunicorn configuration and environment variables

## Review & Testing Checklist for Human

- [ ] **Verify Docker build works locally**: Run `docker build -t maturity-test .` and confirm no build errors
- [ ] **Test reportlab import in Docker**: Run container and verify `from reportlab.lib.pagesizes import A4` works
- [ ] **Monitor Render deployment logs**: After merging, check that Render build succeeds without GCC compilation errors
- [ ] **End-to-end PDF functionality test**: Create a meeting design and export PDF to ensure reportlab works correctly in production
- [ ] **Verify environment variables**: Confirm DATABASE_URL and other env vars are properly passed to Docker container

**Recommended test plan**: After deployment, navigate to meeting design feature, create a test meeting, and attempt PDF export to verify the fix resolves the original issue.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A[".render.yaml"]:::major-edit --> B["Render Platform"]:::context
    C["Dockerfile"]:::major-edit --> B
    D["requirements.txt"]:::context --> C
    E["meeting_design.py"]:::context --> F["reportlab library"]:::context
    C --> F
    B --> G["Production App"]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This is a critical fix for the deployment failure blocking the meeting design functionality
- The Docker approach is recommended by Render for projects requiring OS-level packages
- Local testing confirmed reportlab installs successfully, but Render environment testing is still needed
- No changes to application code - purely infrastructure/deployment fixes

**Link to Devin run**: https://app.devin.ai/sessions/7d2766db99de4905b04ea106d8796b5e  
**Requested by**: @st53182