### PR TITLE
Fix template saving and restore question preview modal

### DIFF
--- a/vue-frontend/src/components/TemplateEditor.vue
+++ b/vue-frontend/src/components/TemplateEditor.vue
@@ -141,6 +141,29 @@ export default {
     async saveTemplate() {
       try {
         const token = localStorage.getItem('token')
+        
+        if (!this.templateName.trim()) {
+          alert('Название шаблона обязательно')
+          return
+        }
+        
+        if (!this.questions || this.questions.length === 0) {
+          alert('Добавьте хотя бы один вопрос')
+          return
+        }
+        
+        for (let i = 0; i < this.questions.length; i++) {
+          const question = this.questions[i]
+          if (!question.question || !question.question.trim()) {
+            alert(`Вопрос ${i + 1}: Текст вопроса обязателен`)
+            return
+          }
+          if (!question.type) {
+            alert(`Вопрос ${i + 1}: Тип вопроса обязателен`)
+            return
+          }
+        }
+        
         const templateData = {
           name: this.templateName,
           survey_type: this.surveyType,
@@ -161,7 +184,9 @@ export default {
         this.$emit('close')
       } catch (error) {
         console.error('Error saving template:', error)
-        alert('Ошибка сохранения шаблона')
+        console.error('Response data:', error.response?.data)
+        const errorMessage = error.response?.data?.error || error.response?.data?.message || error.message
+        alert(`Ошибка сохранения шаблона: ${errorMessage}`)
       }
     }
   }


### PR DESCRIPTION
# Fix template saving and restore question preview modal

## Summary

This PR addresses two critical survey functionality issues reported by the user:

1. **Template saving validation errors**: Enhanced the `TemplateEditor` component with comprehensive frontend validation and improved error handling to address 422/404 errors when saving survey templates.

2. **Missing question preview modal**: Restored the `QuestionPreview` component integration that was accidentally removed, allowing users to see and edit questions before creating surveys.

**Key Changes:**
- Added frontend validation in `TemplateEditor.vue` to catch common issues before API calls
- Restored `QuestionPreview` component integration in survey creation flow  
- Added back missing default question methods for e-NPS and 360° surveys
- Modified survey creation to show preview modal before final creation
- Enhanced error reporting with detailed backend error messages

## Review & Testing Checklist for Human

- [ ] **Test template saving end-to-end**: Create and edit custom templates to verify validation works and error messages are helpful
- [ ] **Verify question preview modal**: Create surveys of both types (e-NPS, 360°) and confirm preview modal appears with correct questions before creation
- [ ] **Test complete survey creation flow**: Ensure surveys still create successfully after the preview step and links are properly generated
- [ ] **Validate default questions**: Check that the hardcoded default questions for e-NPS and 360° surveys match expected format and create functional surveys
- [ ] **Test error scenarios**: Try saving invalid templates to verify frontend validation catches issues and backend errors display properly

**Recommended Test Plan:**
1. Navigate to surveys section
2. Try creating e-NPS survey → verify preview modal shows with 9 questions  
3. Try creating 360° survey → verify preview modal shows with 6 questions
4. Test "Edit Questions" button from preview modal
5. Create custom template with validation errors (empty fields)
6. Create valid custom template and verify it saves

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Surveys["vue-frontend/src/views/Surveys.vue"]:::major-edit --> QuestionPreview["vue-frontend/src/components/QuestionPreview.vue"]:::context
    Surveys --> TemplateEditor["vue-frontend/src/components/TemplateEditor.vue"]:::major-edit
    Surveys --> Backend["surveys.py<br/>/api/survey-templates"]:::context
    
    QuestionPreview --> |"show preview before creation"| CreateFlow["Survey Creation Flow"]:::context
    TemplateEditor --> |"enhanced validation"| SaveTemplate["Template Saving"]:::context
    
    Surveys --> |"getDefaultEnpsQuestions()<br/>getDefault360Questions()"| DefaultQuestions["Default Question Methods"]:::major-edit
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This PR assumes the `QuestionPreview` component from the previous PR is working correctly
- Default question structures are hardcoded and should be validated against actual survey requirements
- Frontend validation may not solve underlying backend issues if the 404/422 errors are server-side problems
- The survey creation flow has been significantly modified - thorough testing of the user experience is recommended

---

*This PR was created by Devin AI*  
*Link to Devin run: https://app.devin.ai/sessions/696243386c2c41e9bf5cc73c5941f73e*  
*Requested by: @st53182*